### PR TITLE
Fix for #12 - no_semicolon.c should fail on missing parens

### DIFF
--- a/stage_1/invalid/no_semicolon.c
+++ b/stage_1/invalid/no_semicolon.c
@@ -1,3 +1,3 @@
-int main {
+int main() {
     return 0
 }


### PR DESCRIPTION
no_semicolon.c should not fail on missing parens, there's already another test for that.