### PR TITLE
Invalid case should have valid parens

### DIFF
--- a/stage_1/invalid/no_brace.c
+++ b/stage_1/invalid/no_brace.c
@@ -1,2 +1,2 @@
-int main {
+int main() {
     return 0;


### PR DESCRIPTION
Invalid case should fail because of missing brace, not missing parens.